### PR TITLE
[Fix] Replace `pnpm` with yarn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
         id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # 1.5.3
         with:
-          publish: pnpm changeset publish
-          version: pnpm changeset:version-and-format
+          publish: yarn changeset publish
+          version: yarn changeset:version-and-format
           commit: 'ci(changesets): version packages'
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}


### PR DESCRIPTION
### Summary
Replace `pnpm` with `yarn`

### Completed Tasks
-  [x] use yarn instead of pnpm to run changeset commands