### PR TITLE
BMU-2640: fix product tailoring sync actions

### DIFF
--- a/.changeset/hungry-moose-hunt.md
+++ b/.changeset/hungry-moose-hunt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+When an `addAsset` action for product-tailoring's variant is generated, the position property is omitted when the source product-tailoring's variant did not include an asset array.

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dist
 
 # custom entries
 bin
+
+# IDEs and editors
+.idea/

--- a/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
+++ b/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
@@ -319,12 +319,17 @@ function _buildVariantAssetsActions(
     );
 
     if (getIsAddAction(key, asset)) {
-      assetActions.push({
+      const action = {
         action: 'addAsset',
         asset: diffpatcher.getDeltaValue(asset),
         ...toVariantIdentifier(newVariant),
+      };
+      const actionWithPosition = {
+        ...action,
         position: Number(key),
-      });
+      };
+      assetActions.push( oldVariant.assets ? actionWithPosition : action );
+
       return;
     }
 

--- a/packages/sync-actions/test/product-tailoring-sync.spec.ts
+++ b/packages/sync-actions/test/product-tailoring-sync.spec.ts
@@ -447,6 +447,30 @@ describe('Actions', () => {
       ]);
     });
 
+    test('should build `addAsset` action without position when previous tailoring does not contain assets', () => {
+      const before = {
+        variants: [{ id: 1, images: [] }],
+      };
+      const now = {
+        variants: [
+          {
+            id: 1,
+            images: [],
+            assets: [{ key: 'asset-1', name: { en: 'Asset 1' }, sources: [] }],
+          },
+        ],
+      };
+
+      const actions = productTailoringSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'addAsset',
+          variantId: 1,
+          asset: { key: 'asset-1', name: { en: 'Asset 1' }, sources: [] },
+        },
+      ]);
+    })
+
     test('should build `removeAsset` action', () => {
       const before = {
         variants: [


### PR DESCRIPTION
**Given** 
A product-tailoring's variant with no assets

**When**
Generating an `addAsset` action

**Then**
It should not specify a `position` where to add that asset.


**Note**
 - `position` is optional. 
 - the sphere backend does not work with `position` if no asset array exists