### PR TITLE
BMU-2640: fix product tailoring sync actions even more

### DIFF
--- a/.changeset/plenty-olives-beg.md
+++ b/.changeset/plenty-olives-beg.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': patch
+---
+
+fix addAsset action generation for product-tailoring when more than one asset is added to a previously undefined asset array

--- a/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
+++ b/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
@@ -303,6 +303,18 @@ function _buildVariantAssetsActions(
   oldVariant: ProductVariantTailoring,
   newVariant: ProductVariantTailoring
 ) {
+  // When before had no `assets` property, jsondiffpatch produces a "property added"
+  // delta [[asset-1, ..., asset-n]] instead of an array diff { _t: 'a', ... }.
+  // getDeltaValue would misread a 2-element inner array as [oldValue, newValue],
+  // so we detect this format and generate addAsset actions directly.
+  if (Array.isArray(diffAssets) && diffAssets.length === 1 && Array.isArray(diffAssets[0])) {
+    return (diffAssets[0] as Asset[]).map((asset) => ({
+      action: 'addAsset',
+      asset,
+      ...toVariantIdentifier(newVariant),
+    }));
+  }
+
   const assetActions = [];
   const matchingAssetPairs = findMatchingPairs(
     diffAssets,

--- a/packages/sync-actions/test/product-tailoring-sync.spec.ts
+++ b/packages/sync-actions/test/product-tailoring-sync.spec.ts
@@ -443,7 +443,7 @@ describe('Actions', () => {
           variantId: 1,
           asset: { key: 'asset-1', name: { en: 'Asset 1' }, sources: [] },
           position: 0,
-        },
+        }
       ]);
     });
 
@@ -470,6 +470,38 @@ describe('Actions', () => {
         },
       ]);
     })
+
+    test('should build `addAsset` action without position when previous tailoring does not contain assets for all new assets', () => {
+      const before = {
+        variants: [{ id: 1, images: [] }],
+      };
+      const now = {
+        variants: [
+          {
+            id: 1,
+            images: [],
+            assets: [
+              { key: 'asset-1', name: { en: 'Asset 1' }, sources: [] },
+              { key: 'asset-2', name: { en: 'Asset 2' }, sources: [] },
+            ],
+          },
+        ],
+      };
+
+      const actions = productTailoringSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'addAsset',
+          variantId: 1,
+          asset: { key: 'asset-1', name: { en: 'Asset 1' }, sources: [] },
+        },
+        {
+          action: 'addAsset',
+          variantId: 1,
+          asset: { key: 'asset-2', name: { en: 'Asset 2' }, sources: [] },
+        },
+      ]);
+    });
 
     test('should build `removeAsset` action', () => {
       const before = {


### PR DESCRIPTION
**Given**
A product-tailoring variant with a non existing asset array

**When**
Adding two assets

**Then**
Two addAsset actions are generated