### PR TITLE
BMU-2640/fix product tailoring sync actions images

### DIFF
--- a/.changeset/bitter-moments-drive.md
+++ b/.changeset/bitter-moments-drive.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': patch
+---
+
+When a product-tailorings variant does not define an image array but more than one image should be added, only one addExternalImage action was generated. This fix makes sure, that for each added image an action is generated

--- a/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
+++ b/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
@@ -194,6 +194,18 @@ function _buildVariantImagesAction(
   oldVariant = {} as ProductVariantTailoring,
   newVariant = {} as ProductVariantTailoring
 ) {
+  // When before had no `images` property, jsondiffpatch produces a "property added"
+  // delta [[image-1, ..., image-n]] instead of an array diff { _t: 'a', ... }.
+  // getDeltaValue would misread a 2-element inner array as [oldValue, newValue],
+  // so we detect this format and generate addExternalImage actions directly.
+  if (Array.isArray(diffedImages) && diffedImages.length === 1 && Array.isArray(diffedImages[0])) {
+    return (diffedImages[0] as Image[]).map((image) => ({
+      action: 'addExternalImage',
+      variantId: oldVariant.id,
+      image,
+    }));
+  }
+
   const actions = [];
   const matchingImagePairs = findMatchingPairs(
     diffedImages,

--- a/packages/sync-actions/test/product-tailoring-sync.spec.ts
+++ b/packages/sync-actions/test/product-tailoring-sync.spec.ts
@@ -318,6 +318,38 @@ describe('Actions', () => {
       ]);
     });
 
+    test('should build multiple `addExternalImage` action when image array is undefined before', () => {
+      const before = {
+        variants: [{ id: 1, assets: [] }],
+      };
+      const now = {
+        variants: [
+          {
+            id: 1,
+            images: [
+              { url: '//newimage-1.jpg', dimensions: { w: 400, h: 300 } },
+              { url: '//newimage-2.jpg', dimensions: { w: 400, h: 300 } },
+            ],
+            assets: [],
+          },
+        ],
+      };
+
+      const actions = productTailoringSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'addExternalImage',
+          variantId: 1,
+          image: { url: '//newimage-1.jpg', dimensions: { w: 400, h: 300 } },
+        },
+        {
+          action: 'addExternalImage',
+          variantId: 1,
+          image: { url: '//newimage-2.jpg', dimensions: { w: 400, h: 300 } },
+        },
+      ]);
+    });
+
     test('should build `removeImage` action', () => {
       const before = {
         variants: [


### PR DESCRIPTION
**Given**
A product-tailoring variant with an undefined image array

**When**
Adding more than one image to that variant

**Then**
All images have a generated addExternalImage action