### PR TITLE
BMU-2640/product tailoring set images action fix

### DIFF
--- a/.changeset/long-hotels-sort.md
+++ b/.changeset/long-hotels-sort.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': patch
+---
+
+Enabling unsetting images on product-tailoring variants.

--- a/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
+++ b/packages/sync-actions/src/product-tailoring/product-tailoring-actions.ts
@@ -194,6 +194,11 @@ function _buildVariantImagesAction(
   oldVariant = {} as ProductVariantTailoring,
   newVariant = {} as ProductVariantTailoring
 ) {
+  // When `images` property is deleted (delta: [oldValue, 0, 0]), generate setImages to unset images.
+  if (Array.isArray(diffedImages) && diffedImages.length === 3 && diffedImages[1] === 0 && diffedImages[2] === 0) {
+    return [{ action: 'setImages', variantId: oldVariant.id }];
+  }
+
   // When before had no `images` property, jsondiffpatch produces a "property added"
   // delta [[image-1, ..., image-n]] instead of an array diff { _t: 'a', ... }.
   // getDeltaValue would misread a 2-element inner array as [oldValue, newValue],

--- a/packages/sync-actions/src/product-tailoring/product-tailoring.ts
+++ b/packages/sync-actions/src/product-tailoring/product-tailoring.ts
@@ -154,10 +154,31 @@ function prepareVariantsForDiff(
   before: ProductTailoringData,
   now: ProductTailoringData
 ): Array<ProductTailoringData> {
+  // Capture which variant IDs lack `images` before copyEmptyArrayProps mutates now
+  // (it does a shallow copy of arrays, so the original elements are shared by reference).
+  const variantIdsWithoutImages = new Set(
+    (now.variants || []).filter((v) => !('images' in v)).map((v) => v.id)
+  );
+
   const [beforeCopy, nowCopy] = copyEmptyArrayProps(
     before,
     now
   ) as Array<ProductTailoringData>;
+
+  // copyEmptyArrayProps adds `images: []` when the property was absent from `now`.
+  // Absence signals removal, so restore it so the diff produces a deletion delta
+  // and a `setImages` action gets generated.
+  if (nowCopy.variants && variantIdsWithoutImages.size > 0) {
+    nowCopy.variants = nowCopy.variants.map((variant) => {
+      if (variantIdsWithoutImages.has(variant.id)) {
+        const { images: _removed, ...rest } = variant as typeof variant & {
+          images?: unknown;
+        };
+        return rest;
+      }
+      return variant;
+    });
+  }
 
   const ensureVariants = (obj: ProductTailoringData): ProductTailoringData => ({
     ...obj,

--- a/packages/sync-actions/src/product-tailoring/product-tailoring.ts
+++ b/packages/sync-actions/src/product-tailoring/product-tailoring.ts
@@ -169,7 +169,7 @@ function prepareVariantsForDiff(
   // Absence signals removal, so restore it so the diff produces a deletion delta
   // and a `setImages` action gets generated.
   if (nowCopy.variants && variantIdsWithoutImages.size > 0) {
-    nowCopy.variants = nowCopy.variants.map((variant) => {
+    const patchedVariants = nowCopy.variants.map((variant) => {
       if (variantIdsWithoutImages.has(variant.id)) {
         const { images: _removed, ...rest } = variant as typeof variant & {
           images?: unknown;
@@ -178,6 +178,7 @@ function prepareVariantsForDiff(
       }
       return variant;
     });
+    (nowCopy as { variants: typeof patchedVariants }).variants = patchedVariants;
   }
 
   const ensureVariants = (obj: ProductTailoringData): ProductTailoringData => ({

--- a/packages/sync-actions/test/product-tailoring-sync.spec.ts
+++ b/packages/sync-actions/test/product-tailoring-sync.spec.ts
@@ -294,6 +294,47 @@ describe('Actions', () => {
   });
 
   describe('image actions', () => {
+    test('should build `setImage` action with undefined images, if images become undefined', () => {
+      const before = {
+        variants: [
+          {
+            id: 1,
+            images: [],
+            assets: [],
+          },
+          {
+            id: 2,
+            images: [
+              { url: '//newimage-1.jpg', dimensions: { w: 400, h: 300 } },
+            ],
+            assets: [],
+          },
+        ],
+      };
+      const now = {
+        variants: [
+          {
+            id: 1,
+            assets: [],
+          }, {
+          id: 2,
+            assets: []
+          }
+        ],
+      };
+
+      const actions = productTailoringSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'setImages',
+          variantId: 1,
+        },
+        {
+          action: 'setImages',
+          variantId: 2,
+        },
+      ]);
+    })
     test('should build `addExternalImage` action', () => {
       const before = {
         variants: [{ id: 1, images: [], assets: [] }],


### PR DESCRIPTION
```typescript
test('should build `setImage` action with undefined images, if images become undefined', () => {
      const before = {
        variants: [
          {
            id: 1,
            images: [],
            assets: [],
          },
          {
            id: 2,
            images: [
              { url: '//newimage-1.jpg', dimensions: { w: 400, h: 300 } },
            ],
            assets: [],
          },
        ],
      };
      const now = {
        variants: [
          {
            id: 1,
            assets: [],
          }, {
          id: 2,
            assets: []
          }
        ],
      };

      const actions = productTailoringSync.buildActions(now, before);
      expect(actions).toEqual([
        {
          action: 'setImages',
          variantId: 1,
        },
        {
          action: 'setImages',
          variantId: 2,
        },
      ]);
    })
    
 ```
