### PR TITLE
BMU-2684: standalone-prices - support staged value via changeValue and removeStagedChanges

### DIFF
--- a/.changeset/staged-standalone-prices.md
+++ b/.changeset/staged-standalone-prices.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sync-actions': minor
+---
+
+standalone-prices: support staged value via `changeValue` with `staged: true` and `removeStagedChanges`

--- a/packages/sync-actions/src/prices/prices-actions.ts
+++ b/packages/sync-actions/src/prices/prices-actions.ts
@@ -1,4 +1,9 @@
-import { Delta, SyncActionConfig, UpdateAction } from '../utils/types';
+import {
+  Delta,
+  StandalonePrice,
+  SyncActionConfig,
+  UpdateAction,
+} from '../utils/types';
 import { buildBaseAttributesActions } from '../utils/common-actions';
 
 export const baseActionsList: Array<UpdateAction> = [
@@ -28,4 +33,33 @@ export function actionsMapBase<T>(
     shouldPreventUnsettingRequiredFields:
       config.shouldPreventUnsettingRequiredFields,
   });
+}
+
+export function actionsMapStaged(
+  diff: Delta,
+  oldObj: Partial<StandalonePrice>,
+  newObj: Partial<StandalonePrice>,
+  config: SyncActionConfig = {}
+) {
+  if (!diff || !diff.staged) return [];
+
+  const hasNewStaged = newObj && newObj.staged != null;
+  const hadOldStaged = oldObj && oldObj.staged != null;
+
+  if (!hasNewStaged && hadOldStaged) {
+    if (config.shouldUnsetOmittedProperties)
+      return [{ action: 'removeStagedChanges' }];
+    return [];
+  }
+
+  if (hasNewStaged && newObj.staged.value)
+    return [
+      {
+        action: 'changeValue',
+        value: newObj.staged.value,
+        staged: true,
+      },
+    ];
+
+  return [];
 }

--- a/packages/sync-actions/src/prices/prices.ts
+++ b/packages/sync-actions/src/prices/prices.ts
@@ -35,8 +35,10 @@ function createPriceMapActions<T extends object>(
   ): Array<UpdateAction> {
     const baseActions = mapActionGroup(
       'base',
-      (): Array<UpdateAction> =>
-        pricesActions.actionsMapBase(diff, oldObj, newObj, syncActionConfig)
+      (): Array<UpdateAction> => [
+        ...pricesActions.actionsMapBase(diff, oldObj, newObj, syncActionConfig),
+        ...pricesActions.actionsMapStaged(diff, oldObj, newObj, syncActionConfig)
+      ]
     );
 
     const customActions = mapActionGroup(

--- a/packages/sync-actions/test/price-sync.spec.ts
+++ b/packages/sync-actions/test/price-sync.spec.ts
@@ -904,6 +904,347 @@ describe('price actions', () => {
     });
   });
 
+  describe('staged', () => {
+    test('should build `changeValue` with `staged: true` when staged value changes', () => {
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2000,
+            fractionDigits: 2,
+          },
+        },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2500,
+            fractionDigits: 2,
+          },
+        },
+      };
+
+      const actions = pricesSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'changeValue',
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2500,
+            fractionDigits: 2,
+          },
+          staged: true,
+        },
+      ]);
+    });
+
+    test('should not build any action when staged value is identical', () => {
+      const stagedValue = {
+        type: 'centPrecision' as const,
+        currencyCode: 'EUR',
+        centAmount: 2000,
+        fractionDigits: 2,
+      };
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: { value: stagedValue },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: { value: stagedValue },
+      };
+
+      const actions = pricesSync.buildActions(now, before);
+      expect(actions).toEqual([]);
+    });
+
+    test('should build `changeValue` with `staged: true` when staged is newly added', () => {
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2500,
+            fractionDigits: 2,
+          },
+        },
+      };
+
+      const actions = pricesSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'changeValue',
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2500,
+            fractionDigits: 2,
+          },
+          staged: true,
+        },
+      ]);
+    });
+
+    test('should build `removeStagedChanges` when staged is removed and `shouldUnsetOmittedProperties` is true', () => {
+      const priceSyncer = pricesSyncFn([], {
+        shouldUnsetOmittedProperties: true,
+      });
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2000,
+            fractionDigits: 2,
+          },
+        },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+      };
+
+      const actions = priceSyncer.buildActions(now, before);
+      expect(actions).toEqual([{ action: 'removeStagedChanges' }]);
+    });
+
+    test('should not build any staged action when staged is removed and `shouldUnsetOmittedProperties` is false', () => {
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2000,
+            fractionDigits: 2,
+          },
+        },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+      };
+
+      const actions = pricesSync.buildActions(now, before);
+      expect(actions).toEqual([]);
+    });
+
+    test('should not build any staged action when neither side has staged', () => {
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+      };
+
+      const actions = pricesSync.buildActions(now, before);
+      expect(actions).toEqual([]);
+    });
+
+    test('should build two `changeValue` actions when both top-level and staged values change', () => {
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2000,
+            fractionDigits: 2,
+          },
+        },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1950,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2500,
+            fractionDigits: 2,
+          },
+        },
+      };
+
+      const actions = pricesSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'changeValue',
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 1950,
+            fractionDigits: 2,
+          },
+        },
+        {
+          action: 'changeValue',
+          value: {
+            type: 'centPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2500,
+            fractionDigits: 2,
+          },
+          staged: true,
+        },
+      ]);
+    });
+
+    test('should detect change in staged value `fractionDigits` for high-precision money', () => {
+      const before: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'highPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2000,
+            fractionDigits: 4,
+            preciseAmount: 200012,
+          } as TypedMoney,
+        },
+      };
+
+      const now: Partial<StandalonePrice> = {
+        id: '9fe6610f',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1900,
+          fractionDigits: 2,
+        },
+        staged: {
+          value: {
+            type: 'highPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2000,
+            fractionDigits: 5,
+            preciseAmount: 2000123,
+          } as TypedMoney,
+        },
+      };
+
+      const actions = pricesSync.buildActions(now, before);
+      expect(actions).toEqual([
+        {
+          action: 'changeValue',
+          value: {
+            type: 'highPrecision',
+            currencyCode: 'EUR',
+            centAmount: 2000,
+            fractionDigits: 5,
+            preciseAmount: 2000123,
+          },
+          staged: true,
+        },
+      ]);
+    });
+  });
+
   describe('setCustomField', () => {
     test('should generate `setCustomField` actions', () => {
       const before: Partial<StandalonePrice> = {


### PR DESCRIPTION
Previously, a staged-only diff on a StandalonePrice produced zero update actions and was silently dropped, because baseActionsList in prices-actions.ts had no entry for `staged`.

The platform exposes two relevant actions: StandalonePriceChangeValueAction (with staged: true) for set/update, and StandalonePriceRemoveStagedChangesAction for removal. Adds actionsMapStaged to emit them, wired into the base action group alongside actionsMapBase. baseActionsList and actionsMapBase are untouched. The change is additive and backward-compatible.
